### PR TITLE
Fixed Error: 'ESP32Logger' does not name a type

### DIFF
--- a/src/ESP32Logger.cpp
+++ b/src/ESP32Logger.cpp
@@ -6,12 +6,10 @@
 // 
 
 
-ESP32Logger Log;
-
-
 #include "ESP32Logger.h"
 #include <stdarg.h>
 
+ESP32Logger Log;
 
 void ESP32Logger::init(Print* output, ESP32Timestamp useTimestamp) {
 	_output = output;


### PR DESCRIPTION
When compiling you might had seen this error. The issue was that ESP32Logger class was initialized before includes